### PR TITLE
enable Nullable reference types in all projects

### DIFF
--- a/src/Commons.Persistence.EntityFramework/Commons.Persistence.EntityFramework.csproj
+++ b/src/Commons.Persistence.EntityFramework/Commons.Persistence.EntityFramework.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	<Nullable>enable</Nullable>
     <VersionPrefix>3.0.0</VersionPrefix>
     <AssemblyName>Queo.Commons.Persistence.EntityFramework</AssemblyName>
     <RootNamespace>Queo.Commons.Persistence.EntityFramework</RootNamespace>

--- a/src/Commons.Persistence/Commons.Persistence.csproj
+++ b/src/Commons.Persistence/Commons.Persistence.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	<Nullable>enable</Nullable>
     <VersionPrefix>3.0.0</VersionPrefix>
     <AssemblyName>Queo.Commons.Persistence</AssemblyName>
     <RootNamespace>Queo.Commons.Persistence</RootNamespace>

--- a/src/Commons.Persistence/Generic/Entity.cs
+++ b/src/Commons.Persistence/Generic/Entity.cs
@@ -5,7 +5,7 @@ namespace Queo.Commons.Persistence.Generic
     public class Entity<TKey>
     {
         private Guid _businessId;
-        private TKey _id;
+        private TKey _id = default!;
 
         /// <summary>
         ///     Initialisiert eine neue Instanz der <see cref="Entity{TKey}" />-Klasse.
@@ -67,7 +67,7 @@ namespace Queo.Commons.Persistence.Generic
         ///     true, wenn das angegebene Objekt und das aktuelle Objekt gleich sind, andernfalls false.
         /// </returns>
         /// <param name="obj">Das Objekt, das mit dem aktuellen Objekt verglichen werden soll.</param>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(this, obj))
             {

--- a/tests/Commons.Persistence.EntityFramework.Tests/Commons.Persistence.EntityFramework.Tests.csproj
+++ b/tests/Commons.Persistence.EntityFramework.Tests/Commons.Persistence.EntityFramework.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	<Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Commons.Persistence.EntityFramework.Tests/Generic/EntityDaoTests.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/Generic/EntityDaoTests.cs
@@ -1,24 +1,20 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Queo.Commons.Persistence.EntityFramework.Generic;
+using Queo.Commons.Persistence.EntityFramework.Tests.TestClasses;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
-using FluentAssertions;
-
-using Microsoft.EntityFrameworkCore;
-
-using NUnit.Framework;
-
-using Queo.Commons.Persistence.EntityFramework.Generic;
-using Queo.Commons.Persistence.EntityFramework.Tests.TestClasses;
 
 namespace Queo.Commons.Persistence.EntityFramework.Tests.Generic
 {
     [TestFixture]
     public class EntityDaoTests : PersistenceBaseTest
     {
-        private DbContextOptions<TestDbContext> contextOptions;
-        private EntityWithStringKey expectedEntity;
+        private DbContextOptions<TestDbContext> contextOptions = null!;
+        private EntityWithStringKey expectedEntity = null!;
 
         //GIVEN: <comment of assumptions>
         [SetUp]

--- a/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/Boo.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/Boo.cs
@@ -4,6 +4,6 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests.TestClasses
 {
     public class Boo : Entity<int>
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 }

--- a/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/EntityWithStringKey.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/EntityWithStringKey.cs
@@ -9,6 +9,6 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests.TestClasses
 
         }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 }

--- a/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/Foo.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/Foo.cs
@@ -5,9 +5,9 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests.TestClasses
     public class Foo : Entity<int>
     {
 
-        public Boo Boo { get; set; }
+        public Boo? Boo { get; set; }
 
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
     }
 }

--- a/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/TestDbContext.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/TestClasses/TestDbContext.cs
@@ -8,8 +8,8 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests.TestClasses
         {
         }
 
-        public DbSet<Foo> Foos { get; set; }
+        public DbSet<Foo> Foos => Set<Foo>();
 
-        public DbSet<EntityWithStringKey> EntityWithStringKeys { get; set; }
+        public DbSet<EntityWithStringKey> EntityWithStringKeys => Set<EntityWithStringKey>();
     }
 }

--- a/tests/Commons.Persistence.Tests/Commons.Persistence.Tests.csproj
+++ b/tests/Commons.Persistence.Tests/Commons.Persistence.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	<Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
The GenericDao.Find(TKey[] ids) methods internally called Get on each id, which leads to n database calls for n ids. Adjusting this to use a more simple "where" call and thus a single database call would require building a much more complex expression to facilitate multi-part keys (which was not feasible within this pull request). As Get now throws if no entry can be found, for now the single Get call per id was replaced by a Exists call + Get if it exists.

fixes issue https://github.com/queoGmbH/csharp-commons.persistence/issues/8


For using EF with nullable reference types also refer to https://learn.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types

