### PR TITLE
Changed GetAll() methods to FindAll()

### DIFF
--- a/src/Commons.Persistence.EntityFramework/Generic/GenericDao.cs
+++ b/src/Commons.Persistence.EntityFramework/Generic/GenericDao.cs
@@ -239,7 +239,17 @@ namespace Queo.Commons.Persistence.EntityFramework.Generic
         ///     Returns a list with all entities.
         /// </summary>
         /// <returns>List with all entities.</returns>
+        [Obsolete("GetAll() is deprecated, please use FindAll() instead.")]
         public virtual IList<TEntity> GetAll()
+        {
+            return FindAll();
+        }
+
+        /// <summary>
+        ///     Returns a list with all entities.
+        /// </summary>
+        /// <returns>List with all entities.</returns>
+        public virtual IList<TEntity> FindAll()
         {
             List<TEntity> entities = _dbContext.Set<TEntity>().ToList();
             return entities;
@@ -249,7 +259,17 @@ namespace Queo.Commons.Persistence.EntityFramework.Generic
         ///     Returns a list with all entities asynchronously.
         /// </summary>
         /// <returns>List with all entities.</returns>
+        [Obsolete("GetAllAsync() is deprecated, please use FindAllAsync() instead.")]
         public virtual async Task<IList<TEntity>> GetAllAsync()
+        {
+            return await FindAllAsync();
+        }
+
+        /// <summary>
+        ///     Returns a list with all entities asynchronously.
+        /// </summary>
+        /// <returns>List with all entities.</returns>
+        public virtual async Task<IList<TEntity>> FindAllAsync()
         {
             List<TEntity> entities = await _dbContext.Set<TEntity>().ToListAsync();
             return entities;

--- a/src/Commons.Persistence/Generic/IGenericDao.cs
+++ b/src/Commons.Persistence/Generic/IGenericDao.cs
@@ -78,13 +78,27 @@ namespace Queo.Commons.Persistence.Generic
         ///     Returns a list with all entities.
         /// </summary>
         /// <returns>List with all entities.</returns>
+        [Obsolete("GetAll() is deprecated, please use FindAll() instead.")]
         IList<T> GetAll();
+
+        /// <summary>
+        ///     Returns a list with all entities.
+        /// </summary>
+        /// <returns>List with all entities.</returns>
+        IList<T> FindAll();
 
         /// <summary>
         ///     Returns a list with all entities asynchronously.
         /// </summary>
         /// <returns>List with all entities.</returns>
+        [Obsolete("GetAllAsync() is deprecated, please use FindAllAsync() instead.")]
         Task<IList<T>> GetAllAsync();
+
+        /// <summary>
+        ///     Returns a list with all entities asynchronously.
+        /// </summary>
+        /// <returns>List with all entities.</returns>
+        Task<IList<T>> FindAllAsync();
 
         /// <summary>
         ///     Returns the number of all objects.

--- a/tests/Commons.Persistence.EntityFramework.Tests/GenericDaoTests.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/GenericDaoTests.cs
@@ -173,7 +173,7 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests
         }
 
         [Test]
-        public void TestGetAll()
+        public void TestFindAll()
         {
             //GIVEN: <comment of assumptions>
             DbContextOptions<TestDbContext> dbContextOptions = GetDbContextOptions<TestDbContext>();
@@ -194,7 +194,7 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests
                 GenericDao<Foo, int> genericDao = new GenericDao<Foo, int>(context);
 
                 //WHEN: <comment on execution>
-                IList<Foo> actualFoos = genericDao.GetAll();
+                IList<Foo> actualFoos = genericDao.FindAll();
 
                 //THEN: <comments on expectations>
                 CollectionAssert.AreEquivalent(expectedFoos, actualFoos);
@@ -202,7 +202,7 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests
         }
 
         [Test]
-        public async Task TestGetAllAsync()
+        public async Task TestFindAllAsync()
         {
             //GIVEN: <comment of assumptions>
             DbContextOptions<TestDbContext> dbContextOptions = GetDbContextOptions<TestDbContext>();
@@ -223,7 +223,7 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests
                 GenericDao<Foo, int> genericDao = new GenericDao<Foo, int>(context);
 
                 //WHEN: <comment on execution>
-                IList<Foo> actualFoos = await genericDao.GetAllAsync();
+                IList<Foo> actualFoos = await genericDao.FindAllAsync();
 
                 //THEN: <comments on expectations>
                 CollectionAssert.AreEquivalent(expectedFoos, actualFoos);

--- a/tests/Commons.Persistence.EntityFramework.Tests/GenericDaoTests.cs
+++ b/tests/Commons.Persistence.EntityFramework.Tests/GenericDaoTests.cs
@@ -202,6 +202,30 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests
         }
 
         [Test]
+        public void TestFindAllWithNoEntitiesExisting()
+        {
+            //GIVEN: <comment of assumptions>
+            DbContextOptions<TestDbContext> dbContextOptions = GetDbContextOptions<TestDbContext>();
+
+            using (TestDbContext context = new TestDbContext(dbContextOptions))
+            {
+                GenericDao<Foo, int> genericDao = new GenericDao<Foo, int>(context);
+                context.SaveChanges();
+            }
+
+            using (TestDbContext context = new TestDbContext(dbContextOptions))
+            {
+                GenericDao<Foo, int> genericDao = new GenericDao<Foo, int>(context);
+
+                //WHEN: <comment on execution>
+                IList<Foo> actualFoos = genericDao.FindAll();
+
+                //THEN: <comments on expectations>
+                actualFoos.Count.Should().Be(0);
+            }
+        }
+
+        [Test]
         public async Task TestFindAllAsync()
         {
             //GIVEN: <comment of assumptions>
@@ -229,6 +253,30 @@ namespace Queo.Commons.Persistence.EntityFramework.Tests
                 CollectionAssert.AreEquivalent(expectedFoos, actualFoos);
             }
         }
+
+        [Test]
+        public async Task TestFindAllAsyncNoEntitiesExisting()
+        {
+            //GIVEN: <comment of assumptions>
+            DbContextOptions<TestDbContext> dbContextOptions = GetDbContextOptions<TestDbContext>();
+            using (TestDbContext context = new TestDbContext(dbContextOptions))
+            {
+                GenericDao<Foo, int> genericDao = new GenericDao<Foo, int>(context);
+                await context.SaveChangesAsync();
+            }
+
+            using (TestDbContext context = new TestDbContext(dbContextOptions))
+            {
+                GenericDao<Foo, int> genericDao = new GenericDao<Foo, int>(context);
+
+                //WHEN: <comment on execution>
+                IList<Foo> actualFoos = await genericDao.FindAllAsync();
+
+                //THEN: <comments on expectations>
+                actualFoos.Count.Should().Be(0);
+            }
+        }
+
         [Test]
         public void TestGetCount()
         {


### PR DESCRIPTION
Introduction of FindAll and FindAllAsync to replace GetAll and GetAllAsync. Existing methods have been marked as obsolete and use newly introduced methods.
Any warnings that occur are dealt with in PullRequest https://github.com/queoGmbH/csharp-commons.persistence/pull/12
AB #47